### PR TITLE
Fix import error

### DIFF
--- a/rdpy/core/const.py
+++ b/rdpy/core/const.py
@@ -32,7 +32,7 @@ class Constant(object):
         @param value: value to protect
         """
         self._value = value
-        
+
     def __get__(self, obj, objType):
         """
         @summary: on get constant return deep copy of wrapped value
@@ -40,16 +40,16 @@ class Constant(object):
         @param objType: unknown
         """
         return deepcopy(self._value)
-    
+
     def __set__(self, obj, value):
         """
         @summary:  Try to set a protect value is forbidden
                     in python 2.7 this function work only
                     on instanciate object
-        @param obj: 
+        @param obj:
         """
         raise Exception("can't assign constant")
-    
+
     def __delete__(self, obj):
         """
         @summary: delete is forbidden on constant
@@ -59,7 +59,7 @@ class Constant(object):
 def TypeAttributes(typeClass):
     """
     @summary:  Call typeClass ctor on each attributes
-                to uniform atributes type on class
+    to uniform atributes type on class
     @param typeClass: class use to construct each class attributes
     @return: class decorator
     """
@@ -73,7 +73,7 @@ def TypeAttributes(typeClass):
 def ConstAttributes(cls):
     """
     @summary:  Copy on read attributes
-                transform all attributes of class 
+                transform all attributes of class
                 in constant attribute
                 only attributes which are not begining with '_' char
                 and are not callable

--- a/rdpy/core/error.py
+++ b/rdpy/core/error.py
@@ -50,7 +50,7 @@ class InvalidExpectedDataException(Exception):
         @param message: message show when exception is raised
         """
         Exception.__init__(self, message)
-        
+
 class NegotiationFailure(Exception):
     """
     @summary: Raise when negotiation failure in different protocols
@@ -60,7 +60,7 @@ class NegotiationFailure(Exception):
         @param message: message show when exception is raised
         """
         Exception.__init__(self, message)
-        
+
 class InvalidType(Exception):
     """
     @summary: Raise when invalid value type occured
@@ -70,7 +70,7 @@ class InvalidType(Exception):
         @param message: message show when exception is raised
         """
         Exception.__init__(self, message)
-        
+
 class InvalidSize(Exception):
     """
     @summary: Raise when invalid size is present in packet type occured
@@ -80,7 +80,7 @@ class InvalidSize(Exception):
         @param message: message show when exception is raised
         """
         Exception.__init__(self, message)
-        
+
 class ErrorReportedFromPeer(Exception):
     """
     @summary: Raise when peer send an error
@@ -90,7 +90,7 @@ class ErrorReportedFromPeer(Exception):
         @param message: message show when exception is raised
         """
         Exception.__init__(self, message)
-        
+
 class RDPSecurityNegoFail(Exception):
     """
     @summary: Raise when security nego fail

--- a/rdpy/core/filetimes.py
+++ b/rdpy/core/filetimes.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2009, David Buxton <david@gasmark6.com>
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
 # met:
-# 
+#
 #     * Redistributions of source code must retain the above copyright
 # notice, this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above copyright
 # notice, this list of conditions and the following disclaimer in the
 # documentation and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 # IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 # TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -65,7 +65,7 @@ def dt_to_filetime(dt):
 
     >>> "%.0f" % dt_to_filetime(datetime(1970, 1, 1, 0, 0))
     '116444736000000000'
-    
+
     >>> dt_to_filetime(datetime(2009, 7, 25, 23, 0, 0, 100))
     128930364000001000
     """
@@ -84,7 +84,7 @@ def filetime_to_dt(ft):
 
     >>> filetime_to_dt(128930364000000000)
     datetime.datetime(2009, 7, 25, 23, 0)
-    
+
     >>> filetime_to_dt(128930364000001000)
     datetime.datetime(2009, 7, 25, 23, 0, 0, 100)
     """
@@ -95,4 +95,3 @@ def filetime_to_dt(ft):
     # Add remainder in as microseconds. Python 3.2 requires an integer
     dt = dt.replace(microsecond=(ns100 // 10))
     return dt
-    

--- a/rdpy/core/layer.py
+++ b/rdpy/core/layer.py
@@ -35,10 +35,10 @@ class IStreamListener(object):
         @param s: Stream
         """
         raise CallPureVirtualFuntion("%s:%s defined by interface %s"%(self.__class__, "recv", "IStreamListener"))
-    
+
 class IStreamSender(object):
     """
-    @summary: Interface use to inform stream sender capability 
+    @summary: Interface use to inform stream sender capability
     """
     def send(self, data):
         """
@@ -46,7 +46,7 @@ class IStreamSender(object):
         @param data: Type or tuple element handle by transport layer
         """
         raise CallPureVirtualFuntion("%s:%s defined by interface %s"%(self.__class__, "send", "IStreamSender"))
-    
+
 class Layer(object):
     """
     @summary:  A simple double linked list with presentation and transport layer
@@ -63,7 +63,7 @@ class Layer(object):
         #auto set transport layer of own presentation layer
         if not self._presentation is None:
             self._presentation._transport = self
-    
+
     def connect(self):
         """
         @summary:  Call when transport layer is connected
@@ -71,7 +71,7 @@ class Layer(object):
         """
         if not self._presentation is None:
             self._presentation.connect()
-    
+
     def close(self):
         """
         @summary:  Close layer event
@@ -79,7 +79,7 @@ class Layer(object):
         """
         if not self._transport is None:
             self._transport.close()
-            
+
 class LayerAutomata(Layer, IStreamListener):
     """
     @summary:  Layer with automata callback
@@ -92,7 +92,7 @@ class LayerAutomata(Layer, IStreamListener):
         """
         #call parent constructor
         Layer.__init__(self, presentation)
-        
+
     def setNextState(self, callback = None):
         """
         @summary: Set the next callback in automata
@@ -100,13 +100,13 @@ class LayerAutomata(Layer, IStreamListener):
         """
         if callback is None:
             callback = lambda x:self.__class__.recv(self, x)
-        
+
         self.recv = callback
 
 #twisted layer concept
 from twisted.internet import protocol
 from twisted.internet.abstract import FileDescriptor
-#first that handle stream     
+#first that handle stream
 from type import Stream
 
 class RawLayerClientFactory(protocol.ClientFactory):
@@ -121,14 +121,14 @@ class RawLayerClientFactory(protocol.ClientFactory):
         rawLayer = self.buildRawLayer(addr)
         rawLayer.setFactory(self)
         return rawLayer
-        
+
     def buildRawLayer(self, addr):
         """
         @summary: Override this function to build raw layer
         @param addr: destination address
         """
         raise CallPureVirtualFuntion("%s:%s defined by interface %s"%(self.__class__, "buildRawLayer", "RawLayerClientFactory"))
-    
+
     def connectionLost(self, rawlayer, reason):
         """
         @summary: Override this method to handle connection lost
@@ -136,7 +136,7 @@ class RawLayerClientFactory(protocol.ClientFactory):
         @param reason: twisted reason
         """
         raise CallPureVirtualFuntion("%s:%s defined by interface %s"%(self.__class__, "connectionLost", "RawLayerClientFactory"))
-    
+
 class RawLayerServerFactory(protocol.ServerFactory):
     """
     @summary: Abstract class for Raw layer server factory
@@ -149,14 +149,14 @@ class RawLayerServerFactory(protocol.ServerFactory):
         rawLayer = self.buildRawLayer(addr)
         rawLayer.setFactory(self)
         return rawLayer
-    
+
     def buildRawLayer(self, addr):
         """
         @summary: Override this function to build raw layer
         @param addr: destination address
         """
         raise CallPureVirtualFuntion("%s:%s defined by interface %s"%(self.__class__, "recv", "IStreamListener"))
-    
+
     def connectionLost(self, rawlayer, reason):
         """
         @summary: Override this method to handle connection lost
@@ -164,7 +164,7 @@ class RawLayerServerFactory(protocol.ServerFactory):
         @param reason: twisted reason
         """
         raise CallPureVirtualFuntion("%s:%s defined by interface %s"%(self.__class__, "recv", "IStreamListener"))
-    
+
 
 class RawLayer(protocol.Protocol, LayerAutomata, IStreamSender):
     """
@@ -183,14 +183,14 @@ class RawLayer(protocol.Protocol, LayerAutomata, IStreamSender):
         #len of next packet pass to next state function
         self._expectedLen = 0
         self._factory = None
-        
+
     def setFactory(self, factory):
         """
         @summary: Call by RawLayer Factory
         @param param: RawLayerClientFactory or RawLayerFactory
         """
         self._factory = factory
-        
+
     def dataReceived(self, data):
         """
         @summary:  Inherit from twisted.protocol class
@@ -207,38 +207,38 @@ class RawLayer(protocol.Protocol, LayerAutomata, IStreamSender):
             self._buffer = self._buffer[self._expectedLen:]
             #call recv function
             self.recv(expectedData)
-            
+
     def connectionMade(self):
         """
         @summary: inherit from twisted protocol
         """
         #join two scheme
         self.connect()
-        
+
     def connectionLost(self, reason):
         """
         @summary: Call from twisted engine when protocol is closed
         @param reason: str represent reason of close connection
         """
         self._factory.connectionLost(self, reason)
-        
+
     def getDescriptor(self):
         """
         @return: the twited file descriptor
         """
         return self.transport
-        
+
     def close(self):
         """
         @summary:  Close raw layer
-                    Use File descriptor directly to not use TLS close
+        Use File descriptor directly to not use TLS close
                     Because is bugged
         """
         FileDescriptor.loseConnection(self.getDescriptor())
-            
+
     def expect(self, expectedLen, callback = None):
         """
-        @summary:  Set next automata callback, 
+        @summary:  Set next automata callback,
                     But this callback will be only called when
                     data have expectedLen
         @param expectedLen: in bytes length use to call next state
@@ -247,7 +247,7 @@ class RawLayer(protocol.Protocol, LayerAutomata, IStreamSender):
         self._expectedLen = expectedLen
         #default callback is recv from LayerAutomata
         self.setNextState(callback)
-        
+
     def send(self, message):
         """
         @summary:  Send Stream on TCP layer

--- a/rdpy/core/layer.py
+++ b/rdpy/core/layer.py
@@ -107,7 +107,7 @@ class LayerAutomata(Layer, IStreamListener):
 from twisted.internet import protocol
 from twisted.internet.abstract import FileDescriptor
 #first that handle stream
-from type import Stream
+from rdpy.core.type import Stream
 
 class RawLayerClientFactory(protocol.ClientFactory):
     """

--- a/rdpy/core/log.py
+++ b/rdpy/core/log.py
@@ -31,7 +31,7 @@ class Level(object):
     WARNING = 2
     ERROR = 3
     NONE = 4
-    
+
 _LOG_LEVEL = Level.DEBUG
 
 def log(message):
@@ -49,7 +49,7 @@ def error(message):
     if _LOG_LEVEL > Level.ERROR:
         return
     log("ERROR:\t%s"%message)
-    
+
 def warning(message):
     """
     @summary: Log warning message
@@ -67,7 +67,7 @@ def info(message):
     if _LOG_LEVEL > Level.INFO:
         return
     log("INFO:\t%s"%message)
-    
+
 def debug(message):
     """
     @summary: Log debug message

--- a/rdpy/core/scancode.py
+++ b/rdpy/core/scancode.py
@@ -49,7 +49,7 @@ _SCANCODE_QWERTY_ = {
     0x31 : "n",
     0x32 : "m"
 }
-        
+
 def scancodeToChar(code):
     """
     @summary: try to convert native code to char code


### PR DESCRIPTION
This PR fix import error.

tested on Python 3.7.4, Mac os x 10.14.5

**StackTrace**
```
Traceback (most recent call last):
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1758, in <module>
    main()
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1752, in main
    globals = debugger.run(setup['file'], None, None, is_module)
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1147, in run
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "%/rdp_test.py", line 1, in <module>
    from rdpy.protocol.rdp import rdp
  File "%/venv/lib/python3.7/site-packages/rdpy/protocol/rdp/rdp.py", line 24, in <module>
    from rdpy.core import layer
  File "%/venv/lib/python3.7/site-packages/rdpy/core/layer.py", line 110, in <module>
    from type import Stream
ModuleNotFoundError: No module named 'type'
```