### PR TITLE
fix in version 3.7  if   security-type is 1  the server does not send…

### DIFF
--- a/rdpy/protocol/rfb/rfb.py
+++ b/rdpy/protocol/rfb/rfb.py
@@ -303,7 +303,10 @@ class RFB(RawLayer):
         if self._securityLevel.value == SecurityType.VNC:
             self.expect(16, self.recvVNCChallenge)
         else:
-            self.expect(4, self.recvSecurityResult)
+            if self._securityLevel.value == SecurityType.NONE and self._version.value == ProtocolVersion.RFB003007:
+                self.sendClientInit()
+            else:
+                self.expect(4, self.recvSecurityResult)
     
     def recvVNCChallenge(self, data):
         """


### PR DESCRIPTION
… the SecurityResult message

reference resources https://datatracker.ietf.org/doc/rfc6143/?include_text=1
A.2.  Differences in the Version 3.7 Protocol			
After the security handshake, if the security-type is 1, for no
   authentication, the server does not send the SecurityResult message
   but proceeds directly to the initialization messages (Section 7.3).