### PR TITLE
fixed for #69 Honeypot not playing the Recorded Session Scenario (RSS)

### DIFF
--- a/bin/rdpy-rdpmitm.py
+++ b/bin/rdpy-rdpmitm.py
@@ -188,9 +188,11 @@ class ProxyClient(rdp.RDPClientObserver):
         @see: rdp.RDPClientObserver.onReady
         """
         self._server.setClient(self)
+        depth = self._controller.getColorDepth()
+        width, height = self._controller.getScreen()
+        self._server._rss.screen(width, height, depth)
         # maybe color depth change
-        self._server._controller.setColorDepth(
-            self._controller.getColorDepth())
+        self._server._controller.setColorDepth(depth)
 
     def onSessionReady(self):
         """


### PR DESCRIPTION
* This bug is caused by the setColorDepth() not be recorded in rss. so it will try to show 32bit image on a 16bit screen!